### PR TITLE
Add very simple retry/backoff strategy for signing commands

### DIFF
--- a/src/app_pass/__main__.py
+++ b/src/app_pass/__main__.py
@@ -126,6 +126,7 @@ def fix(app: OSXAPP, rc_path_delete: bool = False, force_update: bool = False, n
 
 def sign(app: OSXAPP, entitlement_file: Path, developer_id: str) -> list[Command]:
     # For jars, we need to sign and repack before signing  all
+    assert entitlement_file.exists(), entitlement_file
     commands: list[Command] = []
     for jar in app.jars:
         commands.extend(jar.sign(entitlement_file, developer_id))

--- a/src/app_pass/_app.py
+++ b/src/app_pass/_app.py
@@ -315,7 +315,7 @@ def check_rpaths_need_fix(app: OSXAPP, binary: MachOBinary, rc_path_delete: bool
                             f"rpath in {binary.path} pointing outside of binary and allowed system paths, "
                             f"this may indicate build issues {pth}. You can force removal of such paths  "
                             "with `--rc-path-delete`."
-                        )
+                        ),
                     )
                 )
 

--- a/src/app_pass/_commands.py
+++ b/src/app_pass/_commands.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
+
 @dataclass
 class Command:
     # One or multiple commands that can be executed in the shell
@@ -9,6 +10,17 @@ class Command:
     cwd: Optional[Path] = None
     comment: Optional[str] = None
     run_python: bool = True
+    """
+    Some commands are only added for the .sh output (e.g. creating temp directories)
+    Those are marked with run_python=False
+    """
+    retry_backoff: bool = False
+    """
+    More or less a hunch that some commands can fail for various reasons.
+    One such example is codesign, which needs to connect to the apple timestamp
+    server.
+    Mark those commands that something useful can be done ;/
+    """
 
     def to_sh(self) -> list[str]:
         args = [f'"{arg}"' for arg in self.args]

--- a/src/app_pass/_jar.py
+++ b/src/app_pass/_jar.py
@@ -62,7 +62,7 @@ class Jar(BinaryObj):
     def create_commands(self) -> list[Command]:
         return [
             Command(["mkdir", "-p", str(self.temp_path)], run_python=False),
-            Command(["ditto", "-x", "-k", str(self.path), str(self.temp_path)], run_python=False)
+            Command(["ditto", "-x", "-k", str(self.path), str(self.temp_path)], run_python=False),
         ]
 
     def sign(self, entitlement_file, developer_id) -> list[Command]:

--- a/src/app_pass/_macho.py
+++ b/src/app_pass/_macho.py
@@ -361,4 +361,4 @@ def sign_impl(entitlement_file, developer_id, path) -> Command:
         str(path),
     ]
 
-    return Command(args=args)
+    return Command(args=args, retry_backoff=True)

--- a/src/app_pass/_util.py
+++ b/src/app_pass/_util.py
@@ -50,7 +50,7 @@ def run_logged(command: Command) -> str:
             output=out.stdout.decode("utf-8") if out.stdout else "",
         )
 
-    logger.info(f"Successful command {' '.join(command.args)}")
+    logger.debug(f"Successful command {' '.join(command.args)}")
 
     return out.stdout.decode("utf-8")
 

--- a/src/app_pass/_util.py
+++ b/src/app_pass/_util.py
@@ -3,6 +3,7 @@ import logging
 import pathlib
 import struct
 import subprocess
+import time
 from dataclasses import dataclass
 from typing import Iterator, Optional, Tuple
 
@@ -56,9 +57,28 @@ def run_logged(command: Command) -> str:
 
 
 def run_commands(commands: list[Command]):
+    last_backoff = object()
+
     for command in commands:
-        if command.run_python:
-            run_logged(command)
+        if not command.run_python:
+            continue
+
+        if command.retry_backoff:
+            backoff = [10, 30, last_backoff]
+        else:
+            backoff = [last_backoff]
+
+        for sleep_time in backoff:
+            try:
+                run_logged(command)
+            except subprocess.CalledProcessError:
+                pass
+                if sleep_time == last_backoff:
+                    raise
+                logger.info(f"Retrying... after {sleep_time}s")
+                time.sleep(sleep_time)
+            else:
+                break
 
 
 def serialize_to_sh(commands: list[Command], sh_cmd_out: pathlib.Path):


### PR DESCRIPTION
These time out sometimes for now particular reason with timestamp related errors - assuming timestamp server is either busy or temporarily not available or has some rate limit.